### PR TITLE
backslashes necessary to actually show something

### DIFF
--- a/maildir_counter.tmux
+++ b/maildir_counter.tmux
@@ -12,7 +12,7 @@ maildir_counters='@maildir_counters'
 interpolate() {
     local -r status="$1"
     local -r counter="${place_holder/N/$2}"
-    local -r count_files="#(ls -1 $3 | wc -l | xargs)"
+    local -r count_files="#(ls -1 $3 \| wc -l \| xargs)"
     local -r status_value=$(tmux show-option -gqv "$status")
     tmux set-option -gq "$status" "${status_value/$counter/$count_files}"
 }


### PR DESCRIPTION
Without backslashes I don't see anything in my environment. It seems the | are being eaten somehow. Could maybe connected to the IFS change. Not sure if this is only a problem in my environment. But I am not aware of any special configurations.