### PR TITLE
Replace all occurences of the variable in the status

### DIFF
--- a/maildir_counter.tmux
+++ b/maildir_counter.tmux
@@ -14,7 +14,7 @@ interpolate() {
     local -r counter="${place_holder/N/$2}"
     local -r count_files="#(ls -1 $3 | wc -l | xargs)"
     local -r status_value=$(tmux show-option -gqv "$status")
-    tmux set-option -gq "$status" "${status_value/$counter/$count_files}"
+    tmux set-option -gq "$status" "${status_value//$counter/$count_files}"
 }
 
 main() {


### PR DESCRIPTION
If you try to use maildir_counter_1 several times in your status-line, only the first one will be replaced right now. This means you can't use the maildir_counter for conditional status changes. With the added slash `/` before the pattern, the pattern will be replaced on all occurences.