### PR TITLE
Add plugin_interpolated_options support

### DIFF
--- a/maildir_counter.tmux
+++ b/maildir_counter.tmux
@@ -31,9 +31,12 @@ main() {
     IFS=\|
     local i=1
     local toggle_unread_counter=$(tmux show-option -gqv "$maildir_unread_counter")
+    local interpolated_options="$(get_tmux_option "@plugin_interpolated_options" "status-right status-left")"
     for maildir in $(tmux show-option -gqv "$maildir_counters"); do
-        interpolate "status-left" "$i" "$maildir" "$toggle_unread_counter"
-        interpolate "status-right" "$i" "$maildir" "$toggle_unread_counter"
+        for interpolated_option in $interpolated_options
+        do
+            interpolate $interpolated_option "$i" "$maildir" "$toggle_unread_counter"
+        done
         i=$((i+1))
     done
 }

--- a/maildir_counter.tmux
+++ b/maildir_counter.tmux
@@ -10,6 +10,18 @@ place_holder="\#{maildir_counter_N}"
 maildir_counters='@maildir_counters'
 maildir_unread_counter='@maildir_unread_counter'
 
+get_tmux_option() {
+    local option=$1
+    local default_value=$2
+    local option_value="$(tmux show-option -gqv "$option")"
+
+    if [[ -z "$option_value" ]]; then
+        echo "$default_value"
+    else
+        echo "$option_value"
+    fi
+}
+
 interpolate() {
     local -r status="$1"
     local -r counter="${place_holder/N/$2}"
@@ -23,16 +35,16 @@ interpolate() {
     if [ "$enable_unread_counter" == 'yes' ]; then
         count_files_output=$count_files_cur+$count_files_new
     fi
-    local -r status_value=$(tmux show-option -gqv "$status")
+    local -r status_value=$(get_tmux_option "$status")
     tmux set-option -gq "$status" "${status_value//$counter/$count_files_output}"
 }
 
 main() {
     IFS=\|
     local i=1
-    local toggle_unread_counter=$(tmux show-option -gqv "$maildir_unread_counter")
+    local toggle_unread_counter=$(get_tmux_option "$maildir_unread_counter")
     local interpolated_options="$(get_tmux_option "@plugin_interpolated_options" "status-right status-left")"
-    for maildir in $(tmux show-option -gqv "$maildir_counters"); do
+    for maildir in $(get_tmux_option "$maildir_counters"); do
         for interpolated_option in $interpolated_options
         do
             interpolate $interpolated_option "$i" "$maildir" "$toggle_unread_counter"


### PR DESCRIPTION
When using a multi-line status-format, having the interpolation restricted to status_left and status_right is problematic.

This adds an option to configure which options are interpolated by the plugin. Because there are multiple plugins using the same interpolation technique, and they are all subject to the same restrictions, I used "@plugin_interpolated_options" as the option name. That option could be reused by other plugins for the same purpose.

If the option is not found, it defaults to "status-right status-left", the current behavior.


To support multi-line status-format, the status line to interpolate can be added to @plugin_interpolated_options in ~/.tmux.conf:

`set -g @plugin_interpolated_options 'status-format[0] status-left status-right'`


This option also allows a very small improvement in startup performance by only interpolating the necessary options. For example, to only interpolate status-right:

`set -g @plugin_interpolated_options 'status-right'`